### PR TITLE
Fix relation endpoint deletion

### DIFF
--- a/ui/src/context/AnnotationStore.ts
+++ b/ui/src/context/AnnotationStore.ts
@@ -12,6 +12,7 @@ export interface TokenId {
 export class RelationGroup {
     constructor(public sourceIds: string[], public targetIds: string[], public label: Label) {}
 
+    // Delete a relation if it is no longer defined due to deleted source/target annotations
     updateForAnnotationDeletion(a: Annotation): RelationGroup | undefined {
         const sourceEmpty = this.sourceIds.length === 0;
         const targetEmpty = this.targetIds.length === 0;
@@ -19,8 +20,8 @@ export class RelationGroup {
         const newSourceIds = this.sourceIds.filter((id) => id !== a.id);
         const newTargetIds = this.targetIds.filter((id) => id !== a.id);
 
-        const nowSourceEmpty = this.sourceIds.length === 0;
-        const nowTargetEmpty = this.targetIds.length === 0;
+        const nowSourceEmpty = newSourceIds.length === 0;
+        const nowTargetEmpty = newTargetIds.length === 0;
 
         // Only target had any annotations, now it has none,
         // so delete.


### PR DESCRIPTION
This PR updates the UI logic responsible for updating `RelationGroup` objects based on adjustments made to the `targetIds` and `sourceIds` of annotations within the `RelationGroup`.

With existing logic, deleting the target annotation on a relation with a single source and a distinct single target will leave the relation object intact. I expect this is not intended behavior, and is caused by the typo below.
